### PR TITLE
Avoid getting out from screen

### DIFF
--- a/phpwpinfo.php
+++ b/phpwpinfo.php
@@ -631,7 +631,7 @@ class PHP_WP_Info {
 		$output .= '<meta name="robots" content="noindex,nofollow">' . "\n";
 		$output .= '<title>PHPWPInfo</title>' . "\n";
 		$output .= '<link href="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/2.3.2/css/bootstrap.min.css" rel="stylesheet">' . "\n";
-		$output .= '<style>.table tbody tr.warning td{background-color:#FCF8E3;} .description{margin:-10px 0 20px 0;} caption{font-weight: 700;font-size: 18px; margin-bottom: 20px;}</style>' . "\n";
+		$output .= '<style>.table tbody tr.warning td{background-color:#FCF8E3;} .table tbody tr td{word-break: break-all;} .description{margin:-10px 0 20px 0;} caption{font-weight: 700;font-size: 18px; margin-bottom: 20px;}</style>' . "\n";
 		$output .= '</head>' . "\n";
 		$output .= '<body style="padding:10px 0;">' . "\n";
 		$output .= '<div class="container">' . "\n";


### PR DESCRIPTION
Hello there :wave:

Issue on text content going outside the screen (disable function row).
![PHPWPInfo](https://user-images.githubusercontent.com/5576409/157042545-0a1be3c4-3e0c-4788-b0f9-18b776ec6d69.png)
Add break-word to td avoiding this.

Cheers